### PR TITLE
Added support for importing custom server images.

### DIFF
--- a/lib/1and1/image.rb
+++ b/lib/1and1/image.rb
@@ -83,7 +83,7 @@ module OneAndOne
 
 
     def create(server_id: nil, name: nil, description: nil, frequency: nil,
-      num_images: nil)
+      num_images: nil, source: nil, url: nil, os_id: nil, type: nil)
 
       # Build POST body
       new_image = {
@@ -91,7 +91,11 @@ module OneAndOne
         'name' => name,
         'description' => description,
         'frequency' => frequency,
-        'num_images' => num_images
+        'num_images' => num_images,
+        'source' => source,
+        'url' => url,
+        'os_id' => os_id,
+        'type' => type
       }
 
       # Clean out null keys in POST body


### PR DESCRIPTION
Import custom server: because of the new feature that allows to import a custom image, the method POST /images has been enhaced with the parameters: source, url, os_id and type to allow import new images and ISO.